### PR TITLE
(fix) add gui flag to skip relationships

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -285,7 +285,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Contact"
+                            "$ref": "#/definitions/models.ContactJSON"
                         }
                     }
                 ],
@@ -1592,6 +1592,9 @@ const docTemplate = `{
                 "last_modified_token": {
                     "type": "integer"
                 },
+                "metadata": {
+                    "type": "string"
+                },
                 "middle_name": {
                     "type": "string",
                     "example": "Frank"
@@ -1690,6 +1693,130 @@ const docTemplate = `{
                 "other_date_id": {
                     "type": "integer",
                     "example": 456
+                }
+            }
+        },
+        "models.ContactJSON": {
+            "type": "object",
+            "properties": {
+                "addresses": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Address"
+                    }
+                },
+                "anniversary": {
+                    "description": "String for flexible parsing",
+                    "type": "string"
+                },
+                "anniversary_day": {
+                    "type": "integer"
+                },
+                "anniversary_month": {
+                    "type": "integer"
+                },
+                "avatar_base64": {
+                    "type": "string"
+                },
+                "avatar_mime_type": {
+                    "type": "string"
+                },
+                "birthday": {
+                    "description": "String for flexible parsing",
+                    "type": "string"
+                },
+                "birthday_day": {
+                    "type": "integer"
+                },
+                "birthday_month": {
+                    "type": "integer"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "emails": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Email"
+                    }
+                },
+                "etag": {
+                    "type": "string"
+                },
+                "exclude_from_sync": {
+                    "type": "boolean"
+                },
+                "family_name": {
+                    "type": "string"
+                },
+                "full_name": {
+                    "type": "string"
+                },
+                "gender": {
+                    "type": "string"
+                },
+                "given_name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "middle_name": {
+                    "type": "string"
+                },
+                "nickname": {
+                    "type": "string"
+                },
+                "notes": {
+                    "type": "string"
+                },
+                "organizations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Organization"
+                    }
+                },
+                "other_dates": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.OtherDateJSON"
+                    }
+                },
+                "other_relationships": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.OtherRelationship"
+                    }
+                },
+                "phones": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Phone"
+                    }
+                },
+                "prefix": {
+                    "type": "string"
+                },
+                "relationships": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Relationship"
+                    }
+                },
+                "suffix": {
+                    "type": "string"
+                },
+                "uid": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "urls": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.URL"
+                    }
                 }
             }
         },
@@ -1840,6 +1967,27 @@ const docTemplate = `{
                 },
                 "event_date_month": {
                     "description": "1-12, for partial dates",
+                    "type": "integer"
+                },
+                "event_name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                }
+            }
+        },
+        "models.OtherDateJSON": {
+            "type": "object",
+            "properties": {
+                "event_date": {
+                    "description": "Full date string \"2020-01-15\"",
+                    "type": "string"
+                },
+                "event_date_day": {
+                    "type": "integer"
+                },
+                "event_date_month": {
                     "type": "integer"
                 },
                 "event_name": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -277,7 +277,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Contact"
+                            "$ref": "#/definitions/models.ContactJSON"
                         }
                     }
                 ],
@@ -1584,6 +1584,9 @@
                 "last_modified_token": {
                     "type": "integer"
                 },
+                "metadata": {
+                    "type": "string"
+                },
                 "middle_name": {
                     "type": "string",
                     "example": "Frank"
@@ -1682,6 +1685,130 @@
                 "other_date_id": {
                     "type": "integer",
                     "example": 456
+                }
+            }
+        },
+        "models.ContactJSON": {
+            "type": "object",
+            "properties": {
+                "addresses": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Address"
+                    }
+                },
+                "anniversary": {
+                    "description": "String for flexible parsing",
+                    "type": "string"
+                },
+                "anniversary_day": {
+                    "type": "integer"
+                },
+                "anniversary_month": {
+                    "type": "integer"
+                },
+                "avatar_base64": {
+                    "type": "string"
+                },
+                "avatar_mime_type": {
+                    "type": "string"
+                },
+                "birthday": {
+                    "description": "String for flexible parsing",
+                    "type": "string"
+                },
+                "birthday_day": {
+                    "type": "integer"
+                },
+                "birthday_month": {
+                    "type": "integer"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "emails": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Email"
+                    }
+                },
+                "etag": {
+                    "type": "string"
+                },
+                "exclude_from_sync": {
+                    "type": "boolean"
+                },
+                "family_name": {
+                    "type": "string"
+                },
+                "full_name": {
+                    "type": "string"
+                },
+                "gender": {
+                    "type": "string"
+                },
+                "given_name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "middle_name": {
+                    "type": "string"
+                },
+                "nickname": {
+                    "type": "string"
+                },
+                "notes": {
+                    "type": "string"
+                },
+                "organizations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Organization"
+                    }
+                },
+                "other_dates": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.OtherDateJSON"
+                    }
+                },
+                "other_relationships": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.OtherRelationship"
+                    }
+                },
+                "phones": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Phone"
+                    }
+                },
+                "prefix": {
+                    "type": "string"
+                },
+                "relationships": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Relationship"
+                    }
+                },
+                "suffix": {
+                    "type": "string"
+                },
+                "uid": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "urls": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.URL"
+                    }
                 }
             }
         },
@@ -1832,6 +1959,27 @@
                 },
                 "event_date_month": {
                     "description": "1-12, for partial dates",
+                    "type": "integer"
+                },
+                "event_name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                }
+            }
+        },
+        "models.OtherDateJSON": {
+            "type": "object",
+            "properties": {
+                "event_date": {
+                    "description": "Full date string \"2020-01-15\"",
+                    "type": "string"
+                },
+                "event_date_day": {
+                    "type": "integer"
+                },
+                "event_date_month": {
                     "type": "integer"
                 },
                 "event_name": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -120,6 +120,8 @@ definitions:
         type: integer
       last_modified_token:
         type: integer
+      metadata:
+        type: string
       middle_name:
         example: Frank
         type: string
@@ -190,6 +192,89 @@ definitions:
       other_date_id:
         example: 456
         type: integer
+    type: object
+  models.ContactJSON:
+    properties:
+      addresses:
+        items:
+          $ref: '#/definitions/models.Address'
+        type: array
+      anniversary:
+        description: String for flexible parsing
+        type: string
+      anniversary_day:
+        type: integer
+      anniversary_month:
+        type: integer
+      avatar_base64:
+        type: string
+      avatar_mime_type:
+        type: string
+      birthday:
+        description: String for flexible parsing
+        type: string
+      birthday_day:
+        type: integer
+      birthday_month:
+        type: integer
+      created_at:
+        type: string
+      emails:
+        items:
+          $ref: '#/definitions/models.Email'
+        type: array
+      etag:
+        type: string
+      exclude_from_sync:
+        type: boolean
+      family_name:
+        type: string
+      full_name:
+        type: string
+      gender:
+        type: string
+      given_name:
+        type: string
+      id:
+        type: integer
+      middle_name:
+        type: string
+      nickname:
+        type: string
+      notes:
+        type: string
+      organizations:
+        items:
+          $ref: '#/definitions/models.Organization'
+        type: array
+      other_dates:
+        items:
+          $ref: '#/definitions/models.OtherDateJSON'
+        type: array
+      other_relationships:
+        items:
+          $ref: '#/definitions/models.OtherRelationship'
+        type: array
+      phones:
+        items:
+          $ref: '#/definitions/models.Phone'
+        type: array
+      prefix:
+        type: string
+      relationships:
+        items:
+          $ref: '#/definitions/models.Relationship'
+        type: array
+      suffix:
+        type: string
+      uid:
+        type: string
+      updated_at:
+        type: string
+      urls:
+        items:
+          $ref: '#/definitions/models.URL'
+        type: array
     type: object
   models.ContactJSONPatch:
     properties:
@@ -294,6 +379,20 @@ definitions:
         type: integer
       event_date_month:
         description: 1-12, for partial dates
+        type: integer
+      event_name:
+        type: string
+      id:
+        type: integer
+    type: object
+  models.OtherDateJSON:
+    properties:
+      event_date:
+        description: Full date string "2020-01-15"
+        type: string
+      event_date_day:
+        type: integer
+      event_date_month:
         type: integer
       event_name:
         type: string
@@ -711,7 +810,7 @@ paths:
         name: contact
         required: true
         schema:
-          $ref: '#/definitions/models.Contact'
+          $ref: '#/definitions/models.ContactJSON'
       produces:
       - application/json
       responses:

--- a/internal/carddav/server.go
+++ b/internal/carddav/server.go
@@ -86,7 +86,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		s.handlePropfind(w, r)
 	case "REPORT":
 		s.handleReport(w, r)
-	case "GET":
+	case "GET", "HEAD":
 		s.handleGet(w, r)
 	case "PUT":
 		s.handlePut(w, r)
@@ -254,7 +254,7 @@ func (s *Server) handleReport(w http.ResponseWriter, r *http.Request) {
 }
 
 // ========================================
-// GET, PUT, DELETE - Still use path (no XML to parse)
+// GET, HEAD, PUT, DELETE - Still use path (no XML to parse)
 // ========================================
 
 func (s *Server) handleGet(w http.ResponseWriter, r *http.Request) {
@@ -277,6 +277,14 @@ func (s *Server) handleGet(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "text/vcard; charset=utf-8")
 	w.Header().Set("ETag", fmt.Sprintf(`"%s"`, contact.ETag))
+	w.Header().Set("Last-Modified", formatUnixTimestamp(contact.LastModifiedToken))
+	w.Header().Set("Content-Length", strconv.Itoa(buf.Len()))
+
+	if r.Method == "HEAD" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
 	w.Write(buf.Bytes())
 }
 

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -289,7 +289,7 @@ func (h *Handler) CreateContactAPI(w http.ResponseWriter, r *http.Request) {
 //	@Accept			json
 //	@Produce		json
 //	@Param			id		path		int					true	"Contact ID"	minimum(1)
-//	@Param			contact	body		models.Contact		true	"Updated contact information"
+//	@Param			contact	body		models.ContactJSON	true	"Updated contact information"
 //	@Success		200		{object}	models.Contact		"Updated contact"
 //	@Failure		400		{object}	map[string]string	"Invalid request body or contact ID"
 //	@Failure		401		{object}	map[string]string	"Unauthorized"
@@ -322,6 +322,12 @@ func (h *Handler) UpdateContactAPI(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		http.Error(w, "Invalid contact data", http.StatusBadRequest)
 		return
+	}
+
+	// Quick fix for #6 - if saved from the GUI then don't delete and insert relationships
+	queryParams := r.URL.Query().Get("source")
+	if queryParams != "" && queryParams == "GUI" {
+		contact.Metadata = "skip relationships"
 	}
 
 	contact.ID = id

--- a/internal/models/contact.go
+++ b/internal/models/contact.go
@@ -48,6 +48,7 @@ type Contact struct {
 	Relationships      []Relationship      `json:"relationships,omitempty"`
 	OtherRelationships []OtherRelationship `json:"other_relationships,omitempty"`
 	DeletedAt          *time.Time
+	Metadata           string
 }
 
 // GenerateFullName computes the full name from name components

--- a/web/static/js/contact-detail.js
+++ b/web/static/js/contact-detail.js
@@ -232,6 +232,7 @@
                 <option value="website">Website</option>
                 <option value="social">Social</option>
                 <option value="other">Other</option>
+                <option value="other">Immich</option>
             </select>
             <button type="button" class="btn btn-ghost btn-sm btn-square" onclick="this.parentElement.remove(); markFormChanged();">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -761,7 +762,7 @@
                 .filter(d => d.event_date || (d.event_date_month && d.event_date_day)); // Must have valid date
             
             try {
-                const response = await fetch(`/api/v1/contacts/${contactId}`, {
+                const response = await fetch(`/api/v1/contacts/${contactId}?source=GUI`, {
                     method: 'PUT',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify(contact)


### PR DESCRIPTION
added:

```js
const response = await fetch(`/api/v1/contacts/${contactId}?source=GUI`, {
```

and passing this through a new metadata field

```go
// Quick fix for #6 - if saved from the GUI then don't delete and insert relationships
if contact.Metadata == "skip relationships" {
  logger.Debug("[DATABASE] Skipping relationships rebuild due to GUI PUT")
} else {
  tables = append(tables, "relationships")
}
```